### PR TITLE
Remove media taxonomy functionality

### DIFF
--- a/includes/class-custom-post-types.php
+++ b/includes/class-custom-post-types.php
@@ -151,7 +151,7 @@ class Custom_Post_Types {
 			}
 		</style>
 
-		<p><?php esc_html_e( 'Select gender-specific images for this persona. Images will be automatically tagged with the gender and persona name.', 'cme-cpt-and-taxonomy' ); ?></p>
+		<p><?php esc_html_e( 'Select gender-specific images for this persona.', 'cme-cpt-and-taxonomy' ); ?></p>
 
 		<div class="persona-gender-image">
 			<label><strong><?php esc_html_e( 'Male Image', 'cme-cpt-and-taxonomy' ); ?></strong></label><br>
@@ -291,52 +291,21 @@ class Custom_Post_Types {
 		if ( isset( $_POST['persona_image_male'] ) ) {
 			$male_image_id = sanitize_text_field( wp_unslash( $_POST['persona_image_male'] ) );
 			update_post_meta( $post_id, 'persona_image_male', $male_image_id );
-
-			// Add tags to the image.
-			if ( $male_image_id ) {
-				$this->add_tags_to_attachment( $male_image_id, array( 'male', $persona_slug ) );
-			}
+			// Media taxonomy functionality has been removed
 		}
 
 		// Save female image.
 		if ( isset( $_POST['persona_image_female'] ) ) {
 			$female_image_id = sanitize_text_field( wp_unslash( $_POST['persona_image_female'] ) );
 			update_post_meta( $post_id, 'persona_image_female', $female_image_id );
-
-			// Add tags to the image.
-			if ( $female_image_id ) {
-				$this->add_tags_to_attachment( $female_image_id, array( 'female', $persona_slug ) );
-			}
+			// Media taxonomy functionality has been removed
 		}
 
 		// Save indeterminate image.
 		if ( isset( $_POST['persona_image_indeterminate'] ) ) {
 			$indeterminate_image_id = sanitize_text_field( wp_unslash( $_POST['persona_image_indeterminate'] ) );
 			update_post_meta( $post_id, 'persona_image_indeterminate', $indeterminate_image_id );
-
-			// Add tags to the image.
-			if ( $indeterminate_image_id ) {
-				$this->add_tags_to_attachment( $indeterminate_image_id, array( 'indeterminate', $persona_slug ) );
-			}
+			// Media taxonomy functionality has been removed
 		}
-	}
-
-	/**
-	 * Add tags to an attachment.
-	 *
-	 * @since    1.0.0
-	 * @param    int   $attachment_id  The attachment ID.
-	 * @param    array $tags           Tags to add.
-	 * @return   void
-	 */
-	private function add_tags_to_attachment( int $attachment_id, array $tags ): void {
-		// Get existing terms.
-		$existing_terms = wp_get_object_terms( $attachment_id, 'media_tag', array( 'fields' => 'names' ) );
-
-		// Merge with new tags and ensure uniqueness.
-		$all_tags = array_unique( array_merge( $existing_terms, $tags ) );
-
-		// Set the terms.
-		wp_set_object_terms( $attachment_id, $all_tags, 'media_tag' );
 	}
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -134,54 +134,6 @@ class Plugin {
 		// Add welcome notice
 		add_action( 'admin_notices', array( $this, 'display_welcome_notice' ) );
 	}
-
-	/**
-	 * AJAX handler for getting attachment terms.
-	 *
-	 * @since    1.0.0
-	 * @return   void
-	 */
-	public function get_attachment_terms(): void {
-		// Check nonce for security
-		if ( ! isset( $_GET['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['nonce'] ) ), 'media-tags-nonce' ) ) {
-			wp_send_json_error( 'Invalid nonce' );
-		}
-
-		// Check permissions
-		if ( ! current_user_can( 'upload_files' ) ) {
-			wp_send_json_error( 'Permission denied' );
-		}
-
-		// Get attachment ID
-		$attachment_id = isset( $_GET['attachment_id'] ) ? intval( $_GET['attachment_id'] ) : 0;
-		if ( ! $attachment_id ) {
-			wp_send_json_error( 'Invalid attachment ID' );
-		}
-
-		// Get taxonomy
-		$taxonomy = isset( $_GET['taxonomy'] ) ? sanitize_key( $_GET['taxonomy'] ) : 'media_tag';
-
-		// Get terms
-		$terms = get_the_terms( $attachment_id, $taxonomy );
-
-		$formatted_terms = array();
-		if ( $terms && ! is_wp_error( $terms ) ) {
-			foreach ( $terms as $term ) {
-				$formatted_terms[] = array(
-					'term_id' => $term->term_id,
-					'name'    => $term->name,
-					'slug'    => $term->slug,
-				);
-			}
-		}
-
-		wp_send_json_success(
-			array(
-				'terms' => $formatted_terms,
-			)
-		);
-	}
-
 	/**
 	 * Display welcome notice for first-time users.
 	 *

--- a/includes/class-taxonomies.php
+++ b/includes/class-taxonomies.php
@@ -18,18 +18,10 @@ namespace CME_CPT_Taxonomy;
  */
 class Taxonomies {
 	/**
-	 * Taxonomy name for media tags.
-	 *
-	 * @since    1.0.0
-	 * @var      string
-	 */
-	private readonly string $media_taxonomy;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->media_taxonomy = 'media_tag';
+		// Constructor kept for backward compatibility
 	}
 
 	/**
@@ -39,8 +31,8 @@ class Taxonomies {
 	 * @return void
 	 */
 	public function register(): void {
-		// Hook into the init action to register taxonomies.
-		add_action( 'init', [ $this, 'register_taxonomies' ] );
+		// Function kept for backward compatibility
+		// Media taxonomy functionality has been moved to another plugin
 	}
 
 	/**
@@ -50,152 +42,8 @@ class Taxonomies {
 	 * @return void
 	 */
 	public function register_taxonomies(): void {
-		// Register custom taxonomy for the media library.
-		register_taxonomy(
-			$this->media_taxonomy,
-			[ 'attachment', 'persona' ],
-			[
-				'labels'             => [
-					'name'                       => _x(
-						'Media Tags',
-						'taxonomy general name',
-						'cme-cpt-and-taxonomy'
-					),
-					'singular_name'              => _x(
-						'Media Tag',
-						'taxonomy singular name',
-						'cme-cpt-and-taxonomy'
-					),
-					'search_items'               => __(
-						'Search Media Tags',
-						'cme-cpt-and-taxonomy'
-					),
-					'popular_items'              => __(
-						'Popular Media Tags',
-						'cme-cpt-and-taxonomy'
-					),
-					'all_items'                  => __(
-						'All Media Tags',
-						'cme-cpt-and-taxonomy'
-					),
-					'parent_item'                => null,
-					'parent_item_colon'          => null,
-					'edit_item'                  => __(
-						'Edit Media Tag',
-						'cme-cpt-and-taxonomy'
-					),
-					'update_item'                => __(
-						'Update Media Tag',
-						'cme-cpt-and-taxonomy'
-					),
-					'add_new_item'               => __(
-						'Add New Media Tag',
-						'cme-cpt-and-taxonomy'
-					),
-					'new_item_name'              => __(
-						'New Media Tag Name',
-						'cme-cpt-and-taxonomy'
-					),
-					'separate_items_with_commas' => __(
-						'Separate media tags with commas',
-						'cme-cpt-and-taxonomy'
-					),
-					'add_or_remove_items'        => __(
-						'Add or remove media tags',
-						'cme-cpt-and-taxonomy'
-					),
-					'choose_from_most_used'      => __(
-						'Choose from the most used media tags',
-						'cme-cpt-and-taxonomy'
-					),
-					'not_found'                  => __(
-						'No media tags found.',
-						'cme-cpt-and-taxonomy'
-					),
-					'menu_name'                  => __(
-						'Media Tags',
-						'cme-cpt-and-taxonomy'
-					),
-					'back_to_items'              => __(
-						'← Back to Media Tags',
-						'cme-cpt-and-taxonomy'
-					),
-				],
-				'hierarchical'       => false,
-				'show_ui'            => true,
-				'show_in_rest'       => true,
-				'show_admin_column'  => true,
-				'query_var'          => true,
-				'rewrite'            => [ 'slug' => 'media-tag' ],
-				'show_in_menu'       => true,
-				'show_in_nav_menus'  => true,
-				'show_tagcloud'      => true,
-				'show_in_quick_edit' => true,
-			]
-		);
-
-		// Make taxonomy work with attachments.
-		add_filter( 'attachment_fields_to_edit', [ $this, 'add_taxonomy_field' ], 10, 2 );
-		add_filter( 'attachment_fields_to_save', [ $this, 'save_taxonomy_field' ], 10, 2 );
+		// Function kept for backward compatibility
+		// Media taxonomy functionality has been moved to another plugin
 	}
 
-	/**
-	 * Add taxonomy field to attachment edit screen.
-	 *
-	 * @since    1.0.0
-	 * @param    array  $form_fields  Array of form fields.
-	 * @param    object $post         WP_Post object.
-	 * @return   array
-	 */
-	public function add_taxonomy_field( array $form_fields, $post ): array {
-		$taxonomy = get_taxonomy( $this->media_taxonomy );
-
-		if ( ! $taxonomy ) {
-			return $form_fields;
-		}
-
-		$terms  = get_the_terms( $post->ID, $this->media_taxonomy );
-		$values = [];
-
-		if ( ! empty( $terms ) ) {
-			foreach ( $terms as $term ) {
-				$values[] = $term->name;
-			}
-		}
-
-		$form_fields[ $this->media_taxonomy ] = [
-			'label' => $taxonomy->labels->name,
-			'input' => 'text',
-			'value' => join( ', ', $values ),
-			/* translators: %s: the lowercase taxonomy name (e.g. "media tags") */
-			'helps' => sprintf( __( 'Separate %s with commas.', 'cme-cpt-and-taxonomy' ), strtolower( $taxonomy->labels->name ) ),
-		];
-
-		return $form_fields;
-	}
-
-	/**
-	 * Save taxonomy field from attachment edit screen.
-	 *
-	 * @since    1.0.0
-	 * @param    array $post        WP_Post array.
-	 * @param    array $attachment  Attachment fields.
-	 * @return   array
-	 */
-	public function save_taxonomy_field( array $post, array $attachment ): array {
-		if ( isset( $attachment[ $this->media_taxonomy ] ) ) {
-			$taxonomy = get_taxonomy( $this->media_taxonomy );
-
-			if ( ! $taxonomy ) {
-				return $post;
-			}
-
-			$terms = array_map( 'trim', explode( ',', $attachment[ $this->media_taxonomy ] ) );
-
-			// Set the terms for the attachment.
-			wp_set_object_terms( $post['ID'], $terms, $this->media_taxonomy, false );
-		}
-
-		return $post;
-	}
 }


### PR DESCRIPTION
This PR removes the media taxonomy functionality which has been moved to another plugin.

Changes:
- Removed media_taxonomy property and registration
- Removed media tagging functionality from persona handling
- Removed AJAX handlers for media tags
- Updated UI text to remove references to automatic tagging
- Maintained backward compatibility by keeping empty function shells

Testing:
- Verify persona functionality works correctly
- Confirm no media tag features appear in WordPress admin
- Ensure no errors occur when adding/editing personas